### PR TITLE
Makefile: allow to override CC variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 # Compiling is simple - just call make and you should get a mali-memtester executable
 
-CC=gcc
+CC?=gcc
 MEMTESTER_FOLDER=memtester-4.3.0
 
 LDFLAGS=-lGLESv2 -lEGL -lm -pthread


### PR DESCRIPTION
At the moment CC variable is set to gcc without the possibility to
modify it while calling make.

Set CC with `?=` instead of `=`.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>